### PR TITLE
Update theme from jekyll-theme-minimal to minima

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -111,7 +111,7 @@ steps:
         filename: _config.yml
         action_id: file
       - type: gate
-        left: '/^theme:\s?jekyll-theme-minimal$/m'
+        left: '/^theme:\s?minima$/m'
         operator: test
         right: '%actions.file%'
         else:

--- a/responses/03_change-theme.md
+++ b/responses/03_change-theme.md
@@ -10,13 +10,13 @@ You can check out the `_config.yml` file on the **Code** tab of your repository.
 
 ### :keyboard: Activity: Modify the config file
 
-Let's change the `_config.yml` so it's a perfect fit for your new blog. First, we need to use a blog-ready theme. For this activity, we will use a theme named `jekyll-theme-minimal`.
+Let's change the `_config.yml` so it's a perfect fit for your new blog. First, we need to use a blog-ready theme. For this activity, we will use a theme named `minima`.
 
 1. Navigate to the **Code** tab of this repository, and browse to the `_config.yml` file, or click this link [here]({{ repoUrl }}/blob/master/_config.yml).
 2. In the upper right corner, click :pencil2: to open the file editor.
-3. Add a `theme:` set to **jekyll-theme-minimal** so it shows in the `_config.yml` file as below:
+3. Add a `theme:` set to **minima** so it shows in the `_config.yml` file as below:
     ```
-    theme: jekyll-theme-minimal
+    theme: minima
     ```
 4. Modify the other configuration variables such as `title:`, `author:`, and `description:` to customize your site.
 5. Click **Create a new branch for this commit and start a pull request**.

--- a/responses/04_wrong-theme.md
+++ b/responses/04_wrong-theme.md
@@ -1,11 +1,11 @@
-It looks like you changed your theme, but for this activity we want to use `jekyll-theme-minimal`.
+It looks like you changed your theme, but for this activity we want to use `minima`.
 
-### :keyboard: Activity: Change the theme to jekyll-theme-minimal
+### :keyboard: Activity: Change the theme to minima
 
-Let's change the theme to `jekyll-theme-minimal`:
+Let's change the theme to `minima`:
 
 1. At the top of this Pull Request, click the **Files changed** tab.
-2. Click the icon to enter edit mode and change the  `theme:` to **jekyll-theme-minimal**.
+2. Click the icon to enter edit mode and change the  `theme:` to **minima**.
 3. Scroll to the bottom of the window to create a commit.
 4. Enter a commit message then click **Commit changes**.
 


### PR DESCRIPTION
In response to issue https://github.com/githubtraining/github-pages/issues/23 and https://github.com/githubtraining/github-pages/issues/19, posts created during this course are not showing as expected in the GitHub Pages site. This is a result from the theme being used and the way posts are displayed with this particular theme. To get the posts to show as expected in the course, this PR updates the theme from `jekyll-theme-minimal` to `minima`. 

closes #23  
closes #19 

This change updates the necessary responses referencing the theme as well as the theme validation step in the `config.yml` file. 

